### PR TITLE
chore: update heapless to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 sha1 = { version = "0.10.6", default-features = false }
-heapless = { version = "0.7.16", default-features = false }
+heapless = { version = "0.8.0", default-features = false }
 byteorder = { version = "1.5.0", default-features = false }
 httparse = { version = "1.9.5", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-websocket"
-version = "0.9.4"
+version = "0.10.0"
 authors = ["David Haig"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/http.rs
+++ b/src/http.rs
@@ -54,13 +54,13 @@ pub fn read_http_header<'a>(
                         // it is safe to unwrap here because we have checked
                         // the size of the list beforehand
                         sec_websocket_protocol_list
-                            .push(String::from(item))
+                            .push(String::try_from(item)?)
                             .unwrap();
                     }
                 }
             }
             "Sec-WebSocket-Key" => {
-                sec_websocket_key = String::from(str::from_utf8(value)?);
+                sec_websocket_key = String::try_from(str::from_utf8(value)?)?;
             }
             &_ => {
                 // ignore all other headers
@@ -111,7 +111,8 @@ pub fn read_server_connect_handshake_response(
                         }
                     }
                     "Sec-WebSocket-Protocol" => {
-                        sec_websocket_protocol = Some(String::from(str::from_utf8(item.value)?));
+                        sec_websocket_protocol =
+                            Some(String::try_from(str::from_utf8(item.value)?)?);
                     }
                     _ => {
                         // ignore all other headers
@@ -136,7 +137,7 @@ pub fn build_connect_handshake_request(
     let mut key: [u8; 16] = [0; 16];
     rng.fill_bytes(&mut key);
     base64::encode_config_slice(key, base64::STANDARD, &mut key_as_base64);
-    let sec_websocket_key: String<24> = String::from(str::from_utf8(&key_as_base64)?);
+    let sec_websocket_key: String<24> = String::try_from(str::from_utf8(&key_as_base64)?)?;
 
     http_request.push_str("GET ")?;
     http_request.push_str(websocket_options.path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,8 +417,8 @@ where
     /// use embedded_websocket as ws;
     /// let mut buffer: [u8; 1000] = [0; 1000];
     /// let mut ws_server = ws::WebSocketServer::new_server();
-    /// let ws_key = ws::WebSocketKey::from("Z7OY1UwHOx/nkSz38kfPwg==");
-    /// let sub_protocol = ws::WebSocketSubProtocol::from("chat");
+    /// let ws_key = ws::WebSocketKey::try_from("Z7OY1UwHOx/nkSz38kfPwg==").expect("key too long for heapless::String");
+    /// let sub_protocol = ws::WebSocketSubProtocol::try_from("chat").expect("subprotocol too long for heapless::String");
     /// let len = ws_server
     ///     .server_accept(&ws_key, Some(&sub_protocol), &mut buffer)
     ///     .unwrap();
@@ -522,7 +522,7 @@ where
     /// ```
     /// use embedded_websocket as ws;
     /// let mut ws_client = ws::WebSocketClient::new_client(rand::thread_rng());
-    /// let ws_key = ws::WebSocketKey::from("Z7OY1UwHOx/nkSz38kfPwg==");
+    /// let ws_key = ws::WebSocketKey::try_from("Z7OY1UwHOx/nkSz38kfPwg==").expect("key too long for heapless::String");
     /// let server_response_html = "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Protocol: chat\r\nSec-WebSocket-Accept: ptPnPeDOTo6khJlzmLhOZSh2tAY=\r\n\r\n";    ///
     /// let (len, sub_protocol) = ws_client.client_accept(&ws_key, server_response_html.as_bytes())
     ///     .unwrap();
@@ -1135,8 +1135,10 @@ Upgrade: websocket
     fn server_accept_should_write_sub_protocol() {
         let mut buffer: [u8; 1000] = [0; 1000];
         let mut ws_server = WebSocketServer::new_server();
-        let ws_key = WebSocketKey::from("Z7OY1UwHOx/nkSz38kfPwg==");
-        let sub_protocol = WebSocketSubProtocol::from("chat");
+        let ws_key = WebSocketKey::try_from("Z7OY1UwHOx/nkSz38kfPwg==")
+            .expect("Key too long for heapless::String");
+        let sub_protocol = WebSocketSubProtocol::try_from("chat")
+            .expect("Subprotocol too long for heapless::String");
         let size = ws_server
             .server_accept(&ws_key, Some(&sub_protocol), &mut buffer)
             .unwrap();


### PR DESCRIPTION
Heapless 0.8.0.is out for a long time ... 

Could you please merge this patch and release new version to crates.io?

I'd like to get rid of a duplicate dependency on heapless 0.7 in my embedded project.